### PR TITLE
Add new `Capabilities` field containing environment capabilities. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new `Capabilities` field containing environment capabilities. For now it only contains availability zones.
+
 ## [1.2.0] - 2021-07-13
 
 ### Changed

--- a/cmd/daemon/runner.go
+++ b/cmd/daemon/runner.go
@@ -80,6 +80,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			InstallationK8sApiUrl:  r.viper.GetString("kubernetes.apiUrl"),
 			InstallationK8sAuthUrl: r.viper.GetString("kubernetes.authUrl"),
 			InstallationK8sCaCert:  r.viper.GetString("kubernetes.caCert"),
+			AvailabilityZones:      r.viper.GetStringSlice("capabilities.availabilityZones"),
 		}
 
 		s, err = server.New(c)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
-	github.com/vektah/gqlparser/v2 v2.2.0
+	github.com/vektah/gqlparser/v2 v2.1.0
 	go.uber.org/zap v1.18.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -276,9 +276,8 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/vektah/dataloaden v0.2.1-0.20190515034641-a19b9a6e7c9e/go.mod h1:/HUdMve7rvxZma+2ZELQeNh88+003LL7Pf/CZ089j8U=
+github.com/vektah/gqlparser/v2 v2.1.0 h1:uiKJ+T5HMGGQM2kRKQ8Pxw8+Zq9qhhZhz/lieYvCMns=
 github.com/vektah/gqlparser/v2 v2.1.0/go.mod h1:SyUiHgLATUR8BiYURfTirrTcGpcE+4XkV2se04Px1Ms=
-github.com/vektah/gqlparser/v2 v2.2.0 h1:bAc3slekAAJW6sZTi07aGq0OrfaCjj4jxARAaC7g2EM=
-github.com/vektah/gqlparser/v2 v2.2.0/go.mod h1:i3mQIGIrbK2PD1RrCeMTlVbkF2FJ6WkU1KJlJlC+3F4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/helm/athena/templates/configmap.yaml
+++ b/helm/athena/templates/configmap.yaml
@@ -18,3 +18,10 @@ data:
       apiUrl: "{{ .Values.kubernetes.api.address }}"
       authUrl: "{{ .Values.oidc.issuerAddress }}"
       caCert: "{{ toYaml .Values.kubernetes.caPem | indent 8 }}"
+    {{- if .Values.provider.availabilityZones }}
+    capabilities:
+      availabilityZones:
+      {{- range .Values.provider.availabilityZones }}
+      - {{ . | quote }}
+      {{- end }}
+    {{- end }}

--- a/helm/athena/values.yaml
+++ b/helm/athena/values.yaml
@@ -26,6 +26,7 @@ oidc:
 
 provider:
   kind: ""
+  availabilityZones: []
 
 security:
   subnet:

--- a/internal/config/capabilities.go
+++ b/internal/config/capabilities.go
@@ -1,0 +1,5 @@
+package config
+
+type Capabilities struct {
+	AvailabilityZones []string
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,9 +1,10 @@
 package config
 
 type Flags struct {
-	Server     Server
-	Identity   Identity
-	Kubernetes Kubernetes
+	Server       Server
+	Identity     Identity
+	Kubernetes   Kubernetes
+	Capabilities Capabilities
 }
 
 func New() *Flags {

--- a/pkg/graph/exec/generated.go
+++ b/pkg/graph/exec/generated.go
@@ -12,10 +12,9 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/introspection"
+	"github.com/giantswarm/athena/pkg/graph/model"
 	gqlparser "github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
-
-	"github.com/giantswarm/athena/pkg/graph/model"
 )
 
 // region    ************************** generated!.gotpl **************************
@@ -43,6 +42,10 @@ type DirectiveRoot struct {
 }
 
 type ComplexityRoot struct {
+	Capabilities struct {
+		AvailabilityZones func(childComplexity int) int
+	}
+
 	Identity struct {
 		Codename func(childComplexity int) int
 		Provider func(childComplexity int) int
@@ -55,12 +58,14 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		Identity   func(childComplexity int) int
-		Kubernetes func(childComplexity int) int
+		Capabilities func(childComplexity int) int
+		Identity     func(childComplexity int) int
+		Kubernetes   func(childComplexity int) int
 	}
 }
 
 type QueryResolver interface {
+	Capabilities(ctx context.Context) (*model.Capabilities, error)
 	Identity(ctx context.Context) (*model.Identity, error)
 	Kubernetes(ctx context.Context) (*model.Kubernetes, error)
 }
@@ -79,6 +84,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 	ec := executionContext{nil, e}
 	_ = ec
 	switch typeName + "." + field {
+
+	case "Capabilities.availabilityZones":
+		if e.complexity.Capabilities.AvailabilityZones == nil {
+			break
+		}
+
+		return e.complexity.Capabilities.AvailabilityZones(childComplexity), true
 
 	case "Identity.codename":
 		if e.complexity.Identity.Codename == nil {
@@ -114,6 +126,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Kubernetes.CaCert(childComplexity), true
+
+	case "Query.capabilities":
+		if e.complexity.Query.Capabilities == nil {
+			break
+		}
+
+		return e.complexity.Query.Capabilities(childComplexity), true
 
 	case "Query.identity":
 		if e.complexity.Query.Identity == nil {
@@ -179,6 +198,14 @@ func (ec *executionContext) introspectType(name string) (*introspection.Type, er
 }
 
 var sources = []*ast.Source{
+	{Name: "pkg/graph/graphql/capabilities.graphql", Input: `type Capabilities {
+  availabilityZones: [String!]!
+}
+
+extend type Query {
+  capabilities: Capabilities!
+}
+`, BuiltIn: false},
 	{Name: "pkg/graph/graphql/identity.graphql", Input: `type Identity {
   provider: String!
   codename: String!
@@ -257,6 +284,41 @@ func (ec *executionContext) field___Type_fields_args(ctx context.Context, rawArg
 // endregion ************************** directives.gotpl **************************
 
 // region    **************************** field.gotpl *****************************
+
+func (ec *executionContext) _Capabilities_availabilityZones(ctx context.Context, field graphql.CollectedField, obj *model.Capabilities) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Capabilities",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AvailabilityZones, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalNString2ᚕstringᚄ(ctx, field.Selections, res)
+}
 
 func (ec *executionContext) _Identity_provider(ctx context.Context, field graphql.CollectedField, obj *model.Identity) (ret graphql.Marshaler) {
 	defer func() {
@@ -431,6 +493,41 @@ func (ec *executionContext) _Kubernetes_caCert(ctx context.Context, field graphq
 	res := resTmp.(string)
 	fc.Result = res
 	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Query_capabilities(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().Capabilities(rctx)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*model.Capabilities)
+	fc.Result = res
+	return ec.marshalNCapabilities2ᚖgithubᚗcomᚋgiantswarmᚋathenaᚋpkgᚋgraphᚋmodelᚐCapabilities(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Query_identity(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -1669,6 +1766,33 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 
 // region    **************************** object.gotpl ****************************
 
+var capabilitiesImplementors = []string{"Capabilities"}
+
+func (ec *executionContext) _Capabilities(ctx context.Context, sel ast.SelectionSet, obj *model.Capabilities) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, capabilitiesImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Capabilities")
+		case "availabilityZones":
+			out.Values[i] = ec._Capabilities_availabilityZones(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var identityImplementors = []string{"Identity"}
 
 func (ec *executionContext) _Identity(ctx context.Context, sel ast.SelectionSet, obj *model.Identity) graphql.Marshaler {
@@ -1753,6 +1877,20 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Query")
+		case "capabilities":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_capabilities(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		case "identity":
 			field := field
 			out.Concurrently(i, func() (res graphql.Marshaler) {
@@ -2056,6 +2194,20 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 	return res
 }
 
+func (ec *executionContext) marshalNCapabilities2githubᚗcomᚋgiantswarmᚋathenaᚋpkgᚋgraphᚋmodelᚐCapabilities(ctx context.Context, sel ast.SelectionSet, v model.Capabilities) graphql.Marshaler {
+	return ec._Capabilities(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNCapabilities2ᚖgithubᚗcomᚋgiantswarmᚋathenaᚋpkgᚋgraphᚋmodelᚐCapabilities(ctx context.Context, sel ast.SelectionSet, v *model.Capabilities) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._Capabilities(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNIdentity2githubᚗcomᚋgiantswarmᚋathenaᚋpkgᚋgraphᚋmodelᚐIdentity(ctx context.Context, sel ast.SelectionSet, v model.Identity) graphql.Marshaler {
 	return ec._Identity(ctx, sel, &v)
 }
@@ -2097,6 +2249,36 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNString2ᚕstringᚄ(ctx context.Context, v interface{}) ([]string, error) {
+	var vSlice []interface{}
+	if v != nil {
+		if tmp1, ok := v.([]interface{}); ok {
+			vSlice = tmp1
+		} else {
+			vSlice = []interface{}{v}
+		}
+	}
+	var err error
+	res := make([]string, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNString2string(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalNString2ᚕstringᚄ(ctx context.Context, sel ast.SelectionSet, v []string) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	for i := range v {
+		ret[i] = ec.marshalNString2string(ctx, sel, v[i])
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {

--- a/pkg/graph/exec/generated.go
+++ b/pkg/graph/exec/generated.go
@@ -12,9 +12,10 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/introspection"
-	"github.com/giantswarm/athena/pkg/graph/model"
-	gqlparser "github.com/vektah/gqlparser/v2"
+	"github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
+
+	"github.com/giantswarm/athena/pkg/graph/model"
 )
 
 // region    ************************** generated!.gotpl **************************

--- a/pkg/graph/graphql/capabilities.graphql
+++ b/pkg/graph/graphql/capabilities.graphql
@@ -1,0 +1,7 @@
+type Capabilities {
+  availabilityZones: [String!]!
+}
+
+extend type Query {
+  capabilities: Capabilities!
+}

--- a/pkg/graph/model/generated.go
+++ b/pkg/graph/model/generated.go
@@ -2,6 +2,10 @@
 
 package model
 
+type Capabilities struct {
+	AvailabilityZones []string `json:"availabilityZones"`
+}
+
 type Identity struct {
 	Provider string `json:"provider"`
 	Codename string `json:"codename"`

--- a/pkg/graph/resolver/capabilities.resolvers.go
+++ b/pkg/graph/resolver/capabilities.resolvers.go
@@ -1,0 +1,24 @@
+package resolver
+
+// This file will be automatically regenerated based on the schema, any resolver implementations
+// will be copied through when generating and any unknown code will be moved to the end.
+
+import (
+	"context"
+
+	"github.com/giantswarm/athena/pkg/graph/exec"
+	"github.com/giantswarm/athena/pkg/graph/model"
+)
+
+func (r *queryResolver) Capabilities(ctx context.Context) (*model.Capabilities, error) {
+	k := &model.Capabilities{
+		AvailabilityZones: r.Resolver.availabilityZones,
+	}
+
+	return k, nil
+}
+
+// Query returns exec.QueryResolver implementation.
+func (r *Resolver) Query() exec.QueryResolver { return &queryResolver{r} }
+
+type queryResolver struct{ *Resolver }

--- a/pkg/graph/resolver/identity.resolvers.go
+++ b/pkg/graph/resolver/identity.resolvers.go
@@ -6,7 +6,6 @@ package resolver
 import (
 	"context"
 
-	"github.com/giantswarm/athena/pkg/graph/exec"
 	"github.com/giantswarm/athena/pkg/graph/model"
 )
 
@@ -18,8 +17,3 @@ func (r *queryResolver) Identity(ctx context.Context) (*model.Identity, error) {
 
 	return i, nil
 }
-
-// Query returns exec.QueryResolver implementation.
-func (r *Resolver) Query() exec.QueryResolver { return &queryResolver{r} }
-
-type queryResolver struct{ *Resolver }

--- a/pkg/graph/resolver/resolver.go
+++ b/pkg/graph/resolver/resolver.go
@@ -21,6 +21,7 @@ type ResolverConfig struct {
 	InstallationK8sApiUrl  string
 	InstallationK8sAuthUrl string
 	InstallationK8sCaCert  string
+	AvailabilityZones      []string
 }
 
 type Resolver struct {
@@ -31,6 +32,7 @@ type Resolver struct {
 	installationK8sApiUrl  string
 	installationK8sAuthUrl string
 	installationK8sCaCert  string
+	availabilityZones      []string
 }
 
 func NewResolver(config ResolverConfig) (*Resolver, error) {
@@ -45,6 +47,7 @@ func NewResolver(config ResolverConfig) (*Resolver, error) {
 		installationK8sApiUrl:  formatUrl(config.InstallationK8sApiUrl),
 		installationK8sAuthUrl: formatUrl(config.InstallationK8sAuthUrl),
 		installationK8sCaCert:  certificate.Parse(config.InstallationK8sCaCert),
+		availabilityZones:      config.AvailabilityZones,
 	}
 
 	return r, nil

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,6 +23,7 @@ type Config struct {
 	InstallationK8sApiUrl  string
 	InstallationK8sAuthUrl string
 	InstallationK8sCaCert  string
+	AvailabilityZones      []string
 }
 
 type Server struct {
@@ -35,6 +36,7 @@ type Server struct {
 	installationK8sApiUrl  string
 	installationK8sAuthUrl string
 	installationK8sCaCert  string
+	availabilityZones      []string
 }
 
 func New(config Config) (*Server, error) {
@@ -57,6 +59,7 @@ func New(config Config) (*Server, error) {
 		installationK8sApiUrl:  config.InstallationK8sApiUrl,
 		installationK8sAuthUrl: config.InstallationK8sAuthUrl,
 		installationK8sCaCert:  config.InstallationK8sCaCert,
+		availabilityZones:      config.AvailabilityZones,
 	}
 
 	return s, nil
@@ -86,6 +89,7 @@ func (s *Server) Boot() error {
 			InstallationK8sApiUrl:  s.installationK8sApiUrl,
 			InstallationK8sAuthUrl: s.installationK8sAuthUrl,
 			InstallationK8sCaCert:  s.installationK8sCaCert,
+			AvailabilityZones:      s.availabilityZones,
 		}
 		rootResolver, err = resolver.NewResolver(config)
 		if err != nil {


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/16806

To allow kubectl-gs to default availability zones we need to know what availability zones are available in each location.
This PR adds support for such field in athena

## Checklist

- [x] Update changelog in CHANGELOG.md.
