### PR TITLE
Add support for submitting RUM events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add support for submitting RUM events.
+- Add support for submitting real user monitoring (RUM) events.
 
 ## [1.3.0] - 2021-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for submitting RUM events.
+
 ## [1.3.0] - 2021-08-26
 
 

--- a/cmd/daemon/flag.go
+++ b/cmd/daemon/flag.go
@@ -7,16 +7,22 @@ import (
 const (
 	configDir  = "config-dir"
 	configFile = "config-file"
+	secretDir  = "secret-dir"
+	secretFile = "secret-file"
 )
 
 type flag struct {
 	ConfigDir  string
 	ConfigFile string
+	SecretDir  string
+	SecretFile string
 }
 
 func (f *flag) Init(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&f.ConfigDir, configDir, ".", "")
 	cmd.PersistentFlags().StringVar(&f.ConfigFile, configFile, "config", "")
+	cmd.PersistentFlags().StringVar(&f.SecretDir, secretDir, ".", "")
+	cmd.PersistentFlags().StringVar(&f.SecretFile, secretFile, "secret", "")
 }
 
 func (f *flag) Validate() error {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/giantswarm/athena
 go 1.16
 
 require (
+	cloud.google.com/go/firestore v1.1.0
+	firebase.google.com/go v3.13.0+incompatible
 	github.com/99designs/gqlgen v0.14.0
 	github.com/giantswarm/microerror v0.3.0
 	github.com/google/go-cmp v0.5.6
@@ -10,6 +12,7 @@ require (
 	github.com/spf13/viper v1.8.1
 	github.com/vektah/gqlparser/v2 v2.2.0
 	go.uber.org/zap v1.19.1
+	google.golang.org/api v0.44.0
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ cloud.google.com/go v0.72.0/go.mod h1:M+5Vjvlc2wnp6tjzE102Dw08nGShTscUx2nZMufOKP
 cloud.google.com/go v0.74.0/go.mod h1:VV1xSbzvo+9QJOxLDaJfTjx5e+MePCpCWwvftOeQmWk=
 cloud.google.com/go v0.78.0/go.mod h1:QjdrLG0uq+YwhjoVOLsS1t7TW8fs36kLs4XO5R5ECHg=
 cloud.google.com/go v0.79.0/go.mod h1:3bzgcEeQlzbuEAYu4mrWhKqWjmpprinYgKJLgKHnbb8=
+cloud.google.com/go v0.81.0 h1:at8Tk2zUz63cLPR0JPWm5vp77pEZmzxEQBEfRKn1VV8=
 cloud.google.com/go v0.81.0/go.mod h1:mk/AM35KwGk/Nm2YSeZbxXdrNK3KZOYHmLkOqC2V6E0=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
@@ -26,6 +27,7 @@ cloud.google.com/go/bigquery v1.7.0/go.mod h1://okPTzCYNXSlb24MZs83e2Do+h+VXtc4g
 cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM77hZzJN/fQ=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
+cloud.google.com/go/firestore v1.1.0 h1:9x7Bx0A9R5/M9jibeJeZWqjeVEIxYW9fZYqB9a70/bY=
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
@@ -35,8 +37,11 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
+cloud.google.com/go/storage v1.10.0 h1:STgFzyU5/8miMl0//zKh2aQeTyeaUH3WN9bSUiJ09bA=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+firebase.google.com/go v3.13.0+incompatible h1:3TdYC3DDi6aHn20qoRkxwGqNgdjtblwVAyRLQwGn/+4=
+firebase.google.com/go v3.13.0+incompatible/go.mod h1:xlah6XbEyW6tbfSklcfe5FHJIwjt8toICdV5Wh9ptHs=
 github.com/99designs/gqlgen v0.14.0 h1:Wg8aNYQUjMR/4v+W3xD+7SizOy6lSvVeQ06AobNQAXI=
 github.com/99designs/gqlgen v0.14.0/go.mod h1:S7z4boV+Nx4VvzMUpVrY/YuHjFX4n7rDyuTqvAkuoRE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -94,6 +99,7 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -119,6 +125,7 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
+github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -136,8 +143,10 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
+github.com/google/martian/v3 v3.1.0 h1:wCKgOCHuUEVfsaQLpPSJb7VdYCdTVZQAuOdYm1yc/60=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -153,6 +162,7 @@ github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLe
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
+github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -189,6 +199,7 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
+github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
@@ -291,6 +302,7 @@ go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
+go.opencensus.io v0.23.0 h1:gqCw0LfLxScz8irSi8exQc7fyQ0fKQU/qnC/X8+V/1M=
 go.opencensus.io v0.23.0/go.mod h1:XItmlyltB5F7CS4xOC1DcqMoFqwtC6OG2xF7mCv7P7E=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
@@ -331,6 +343,7 @@ golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRu
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
@@ -379,6 +392,7 @@ golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -391,6 +405,7 @@ golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602 h1:0Ja1LBD+yisY6RWM/BH7TJVXWsSjs2VwBSmvSX4HdBc=
 golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -540,6 +555,7 @@ google.golang.org/api v0.36.0/go.mod h1:+z5ficQTmoYpPn8LCUNVpK5I7hwkpjbcgqA7I34q
 google.golang.org/api v0.40.0/go.mod h1:fYKFpnQN0DsDSKRVRcQSDQNtqWPfM9i+zNPxepjRCQ8=
 google.golang.org/api v0.41.0/go.mod h1:RkxM5lITDfTzmyKFPt+wGrCJbVfniCr2ool8kTBzRTU=
 google.golang.org/api v0.43.0/go.mod h1:nQsDGjRXMo4lvh5hP0TKqF244gqhGcr/YSIykhUk/94=
+google.golang.org/api v0.44.0 h1:URs6qR1lAxDsqWITsQXI4ZkGiYJ5dHtRNiCpfs2OeKA=
 google.golang.org/api v0.44.0/go.mod h1:EBOGZqzyhtvMDoxwS97ctnh0zUmYY6CxqXsc1AvkYD8=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -547,6 +563,7 @@ google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -588,6 +605,7 @@ google.golang.org/genproto v0.0.0-20210303154014-9728d6b83eeb/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210310155132-4ce2db91004e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
+google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c h1:wtujag7C+4D6KMoulW9YauvK2lgdvCMS260jsqqBXr0=
 google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
@@ -608,6 +626,7 @@ google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA5
 google.golang.org/grpc v1.35.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.36.1/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
+google.golang.org/grpc v1.38.0 h1:/9BgsAsa5nWe26HqOlvlgJnqBuktYOLCgjCPqsa56W0=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
@@ -620,6 +639,7 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/helm/athena/templates/configmap.yaml
+++ b/helm/athena/templates/configmap.yaml
@@ -18,3 +18,5 @@ data:
       apiUrl: "{{ .Values.kubernetes.api.address }}"
       authUrl: "{{ .Values.oidc.issuerAddress }}"
       caCert: "{{ toYaml .Values.kubernetes.caPem | indent 8 }}"
+    analytics:
+      environmentType: {{ .Values.environmentType}}

--- a/helm/athena/templates/deployment.yaml
+++ b/helm/athena/templates/deployment.yaml
@@ -27,6 +27,12 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
+      - name: "{{ .Values.name }}-secret"
+        secret:
+          secretName: "{{ .Values.name }}-secret"
+          items:
+          - key: secret.yaml
+            path: secret.yaml
       securityContext:
         runAsUser: {{ .Values.userID }}
         runAsGroup: {{ .Values.groupID }}
@@ -36,8 +42,10 @@ spec:
         imagePullPolicy: Always
         args:
         - "daemon"
-        - "--config-dir=/var/run/athena/configmap/"
+        - "--config-dir=/var/run/{{ .Values.name }}/configmap/"
         - "--config-file=config"
+        - "--secret-dir=/var/run/{{ .Values.name }}/secret/"
+        - "--secret-file=secret"
         ports:
         - containerPort: 8000
           name: http
@@ -50,7 +58,10 @@ spec:
             memory: 250Mi
         volumeMounts:
         - name: "{{ .Values.name }}-configmap"
-          mountPath: /var/run/athena/configmap/
+          mountPath: "/var/run/{{ .Values.name }}/configmap/"
+          readOnly: true
+        - name: "{{ .Values.name }}-secret"
+          mountPath: "/var/run/{{ .Values.name }}/secret/"
           readOnly: true
         livenessProbe:
           httpGet:

--- a/helm/athena/templates/secret.yaml
+++ b/helm/athena/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: "{{ .Values.name }}-secret"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.name }}
+stringData:
+  secret.yaml: |
+    analytics:
+      credentialsJSON: {{ .Values.secret.firestoreServiceAccountKey | toJson }}

--- a/helm/athena/values.yaml
+++ b/helm/athena/values.yaml
@@ -44,6 +44,13 @@ services:
     host: ""
     letsencrypt: true
 
+analytics:
+  environmentType: ""
+  credentialsJSON: ""
+
+secret:
+  firestoreServiceAccountKey: ""
+
 # generic configuration
 registry:
   domain: docker.io

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -1,0 +1,99 @@
+package analytics
+
+import (
+	"context"
+
+	"cloud.google.com/go/firestore"
+	firebase "firebase.google.com/go"
+	"github.com/giantswarm/microerror"
+	"go.uber.org/zap"
+	"google.golang.org/api/option"
+)
+
+type Config struct {
+	Log *zap.SugaredLogger
+
+	CredentialsJSON string
+	Environment     string
+}
+
+type Analytics struct {
+	log             *zap.SugaredLogger
+	firestoreClient *firestore.Client
+
+	environment string
+}
+
+func New(config Config) (*Analytics, error) {
+	if config.Log == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Log must not be empty", config)
+	}
+	if len(config.CredentialsJSON) < 1 {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CredentialsJSON must not be empty", config)
+	}
+
+	var firestoreClient *firestore.Client
+	{
+		ctx := context.Background()
+		credentials := option.WithCredentialsJSON([]byte(config.CredentialsJSON))
+
+		app, err := firebase.NewApp(ctx, nil, credentials)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		firestoreClient, err = app.Firestore(ctx)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	a := &Analytics{
+		log:             config.Log,
+		firestoreClient: firestoreClient,
+	}
+
+	return a, nil
+}
+
+func (a *Analytics) Report(ctx context.Context, e Event) (Event, error) {
+	a.log.Debugf("received event for session %s on app %s", e.SessionID, e.AppID)
+
+	a.log.Debugf("applying defaults to event for session %s on app %s", e.SessionID, e.AppID)
+
+	e = a.applyDefaultsToEvent(e)
+
+	a.log.Debugf("validating event for session %s on app %s", e.SessionID, e.AppID)
+
+	err := a.validateEvent(e)
+	if err != nil {
+		return Event{}, microerror.Mask(err)
+	}
+
+	a.log.Debugf("writing event record for session %s on app %s", e.SessionID, e.AppID)
+
+	_, _, err = a.firestoreClient.Collection(e.CollectionName()).Add(ctx, e)
+	if err != nil {
+		return Event{}, microerror.Mask(err)
+	}
+
+	a.log.Debugf("wrote event record for session %s on app %s successfully", e.SessionID, e.AppID)
+
+	return e, nil
+}
+
+func (a *Analytics) validateEvent(e Event) error {
+	if !e.AppID.IsValid() {
+		return microerror.Maskf(validationError, "unknown app id")
+	}
+
+	return nil
+}
+
+func (a *Analytics) applyDefaultsToEvent(e Event) Event {
+	if len(e.EnvironmentClass) < 1 {
+		e.EnvironmentClass = a.environment
+	}
+
+	return e
+}

--- a/pkg/analytics/appid.go
+++ b/pkg/analytics/appid.go
@@ -1,0 +1,21 @@
+package analytics
+
+type AppID string
+
+const (
+	AppIDHappa = iota
+)
+
+var appIDs = [...]AppID{
+	AppIDHappa: "happa",
+}
+
+func (a AppID) IsValid() bool {
+	for _, id := range appIDs {
+		if id == a {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/analytics/error.go
+++ b/pkg/analytics/error.go
@@ -1,0 +1,25 @@
+package analytics
+
+import (
+	"errors"
+
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return errors.Is(err, invalidConfigError)
+}
+
+var validationError = &microerror.Error{
+	Kind: "validationError",
+}
+
+// IsValidation asserts validationError.
+func IsValidation(err error) bool {
+	return errors.Is(err, validationError)
+}

--- a/pkg/analytics/spec.go
+++ b/pkg/analytics/spec.go
@@ -1,0 +1,30 @@
+package analytics
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type Event struct {
+	AppID                AppID                  `firestore:"app_id"`
+	SessionID            string                 `firestore:"session_id"`
+	PayloadType          string                 `firestore:"payload_type"`
+	PayloadSchemaVersion int                    `firestore:"payload_schema_version"`
+	Payload              map[string]interface{} `firestore:"payload"`
+	URI                  string                 `firestore:"uri_path"`
+	Timestamp            time.Time              `firestore:"timestamp"`
+	InstallationID       string                 `firestore:"installation_id"`
+	EnvironmentClass     string                 `firestore:"env_class"`
+}
+
+type Reporter interface {
+	Report(ctx context.Context, event Event) (Event, error)
+}
+
+func (e *Event) CollectionName() string {
+	envClass := strings.ToLower(e.EnvironmentClass)
+
+	return fmt.Sprintf("%s-%s", e.Timestamp.Format("2006-01"), envClass)
+}

--- a/pkg/graph/graphql/analyticsevent.graphql
+++ b/pkg/graph/graphql/analyticsevent.graphql
@@ -1,0 +1,27 @@
+scalar Payload
+scalar Date
+
+type AnalyticsEvent {
+  appID: String!
+  sessionID: String!
+  payloadType: String!
+  payloadSchemaVersion: Int!
+  payload: Payload!
+  uri: String!
+  timestamp: Date!
+  installationID: String!
+  environmentClass: String!
+}
+
+input AnalyticsEventInput {
+  appID: String!
+  sessionID: String!
+  payloadType: String!
+  payloadSchemaVersion: Int!
+  payload: Payload!
+  uri: String!
+}
+
+extend type Mutation {
+  createAnalyticsEvent(event: AnalyticsEventInput!): AnalyticsEvent!
+}

--- a/pkg/graph/model/generated.go
+++ b/pkg/graph/model/generated.go
@@ -2,6 +2,27 @@
 
 package model
 
+type AnalyticsEvent struct {
+	AppID                string `json:"appID"`
+	SessionID            string `json:"sessionID"`
+	PayloadType          string `json:"payloadType"`
+	PayloadSchemaVersion int    `json:"payloadSchemaVersion"`
+	Payload              string `json:"payload"`
+	URI                  string `json:"uri"`
+	Timestamp            string `json:"timestamp"`
+	InstallationID       string `json:"installationID"`
+	EnvironmentClass     string `json:"environmentClass"`
+}
+
+type AnalyticsEventInput struct {
+	AppID                string `json:"appID"`
+	SessionID            string `json:"sessionID"`
+	PayloadType          string `json:"payloadType"`
+	PayloadSchemaVersion int    `json:"payloadSchemaVersion"`
+	Payload              string `json:"payload"`
+	URI                  string `json:"uri"`
+}
+
 type Identity struct {
 	Provider string `json:"provider"`
 	Codename string `json:"codename"`

--- a/pkg/graph/resolver/analyticsevent.resolvers.go
+++ b/pkg/graph/resolver/analyticsevent.resolvers.go
@@ -1,0 +1,76 @@
+package resolver
+
+// This file will be automatically regenerated based on the schema, any resolver implementations
+// will be copied through when generating and any unknown code will be moved to the end.
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/athena/pkg/analytics"
+	"github.com/giantswarm/athena/pkg/graph/exec"
+	"github.com/giantswarm/athena/pkg/graph/model"
+)
+
+const (
+	dateFormat   = time.RFC3339
+	eventTimeout = 2 * time.Second
+)
+
+func (r *mutationResolver) CreateAnalyticsEvent(ctx context.Context, event model.AnalyticsEventInput) (*model.AnalyticsEvent, error) {
+	ctx, cancel := context.WithTimeout(ctx, eventTimeout)
+	defer cancel()
+
+	var err error
+
+	newEventPayload := make(map[string]interface{})
+	{
+		err = json.Unmarshal([]byte(event.Payload), &newEventPayload)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	newEvent := analytics.Event{
+		AppID:                analytics.AppID(event.AppID),
+		SessionID:            event.SessionID,
+		PayloadType:          event.PayloadType,
+		PayloadSchemaVersion: event.PayloadSchemaVersion,
+		Payload:              newEventPayload,
+		URI:                  event.URI,
+		Timestamp:            time.Now().UTC(),
+		InstallationID:       r.installationCodename,
+	}
+
+	createdEvent, err := r.analytics.Report(ctx, newEvent)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	createdEventPayload, err := json.Marshal(createdEvent.Payload)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	eventReport := &model.AnalyticsEvent{
+		AppID:                string(createdEvent.AppID),
+		SessionID:            createdEvent.SessionID,
+		PayloadType:          createdEvent.PayloadType,
+		PayloadSchemaVersion: createdEvent.PayloadSchemaVersion,
+		Payload:              string(createdEventPayload),
+		URI:                  createdEvent.URI,
+		Timestamp:            createdEvent.Timestamp.Format(dateFormat),
+		InstallationID:       createdEvent.InstallationID,
+		EnvironmentClass:     createdEvent.EnvironmentClass,
+	}
+
+	return eventReport, nil
+}
+
+// Mutation returns exec.MutationResolver implementation.
+func (r *Resolver) Mutation() exec.MutationResolver { return &mutationResolver{r} }
+
+type mutationResolver struct{ *Resolver }

--- a/pkg/graph/resolver/resolver.go
+++ b/pkg/graph/resolver/resolver.go
@@ -7,6 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"go.uber.org/zap"
 
+	"github.com/giantswarm/athena/pkg/analytics"
 	"github.com/giantswarm/athena/pkg/certificate"
 )
 
@@ -14,17 +15,20 @@ import (
 //go:generate go run ../../../scripts/gqlgen
 
 type ResolverConfig struct {
-	Log *zap.SugaredLogger
+	Log       *zap.SugaredLogger
+	Analytics analytics.Reporter
 
 	InstallationProvider   string
 	InstallationCodename   string
 	InstallationK8sApiUrl  string
 	InstallationK8sAuthUrl string
 	InstallationK8sCaCert  string
+	AnalyticsEnv           string
 }
 
 type Resolver struct {
-	log *zap.SugaredLogger
+	log       *zap.SugaredLogger
+	analytics analytics.Reporter
 
 	installationProvider   string
 	installationCodename   string
@@ -40,6 +44,7 @@ func NewResolver(config ResolverConfig) (*Resolver, error) {
 
 	r := &Resolver{
 		log:                    config.Log,
+		analytics:              config.Analytics,
 		installationProvider:   config.InstallationProvider,
 		installationCodename:   config.InstallationCodename,
 		installationK8sApiUrl:  formatUrl(config.InstallationK8sApiUrl),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"go.uber.org/zap"
 
+	"github.com/giantswarm/athena/pkg/analytics"
 	"github.com/giantswarm/athena/pkg/graph/exec"
 	"github.com/giantswarm/athena/pkg/graph/resolver"
 	"github.com/giantswarm/athena/pkg/server/middleware"
@@ -16,25 +17,29 @@ import (
 type Config struct {
 	Log *zap.SugaredLogger
 
-	AllowedOrigins         []string
-	ListenAddress          string
-	InstallationProvider   string
-	InstallationCodename   string
-	InstallationK8sApiUrl  string
-	InstallationK8sAuthUrl string
-	InstallationK8sCaCert  string
+	AllowedOrigins           []string
+	ListenAddress            string
+	InstallationProvider     string
+	InstallationCodename     string
+	InstallationK8sApiUrl    string
+	InstallationK8sAuthUrl   string
+	InstallationK8sCaCert    string
+	AnalyticsEnv             string
+	AnalyticsCredentialsJSON string
 }
 
 type Server struct {
 	log *zap.SugaredLogger
 
-	allowedOrigins         []string
-	listenAddress          string
-	installationProvider   string
-	installationCodename   string
-	installationK8sApiUrl  string
-	installationK8sAuthUrl string
-	installationK8sCaCert  string
+	allowedOrigins           []string
+	listenAddress            string
+	installationProvider     string
+	installationCodename     string
+	installationK8sApiUrl    string
+	installationK8sAuthUrl   string
+	installationK8sCaCert    string
+	analyticsEnv             string
+	analyticsCredentialsJSON string
 }
 
 func New(config Config) (*Server, error) {
@@ -49,14 +54,16 @@ func New(config Config) (*Server, error) {
 	}
 
 	s := &Server{
-		log:                    config.Log,
-		allowedOrigins:         config.AllowedOrigins,
-		listenAddress:          config.ListenAddress,
-		installationProvider:   config.InstallationProvider,
-		installationCodename:   config.InstallationCodename,
-		installationK8sApiUrl:  config.InstallationK8sApiUrl,
-		installationK8sAuthUrl: config.InstallationK8sAuthUrl,
-		installationK8sCaCert:  config.InstallationK8sCaCert,
+		log:                      config.Log,
+		allowedOrigins:           config.AllowedOrigins,
+		listenAddress:            config.ListenAddress,
+		installationProvider:     config.InstallationProvider,
+		installationCodename:     config.InstallationCodename,
+		installationK8sApiUrl:    config.InstallationK8sApiUrl,
+		installationK8sAuthUrl:   config.InstallationK8sAuthUrl,
+		installationK8sCaCert:    config.InstallationK8sCaCert,
+		analyticsEnv:             config.AnalyticsEnv,
+		analyticsCredentialsJSON: config.AnalyticsCredentialsJSON,
 	}
 
 	return s, nil
@@ -77,10 +84,25 @@ func (s *Server) Boot() error {
 		}
 	}
 
+	var analyticsReporter *analytics.Analytics
+	{
+		c := analytics.Config{
+			Log:             s.log,
+			CredentialsJSON: s.analyticsCredentialsJSON,
+			Environment:     s.analyticsEnv,
+		}
+
+		analyticsReporter, err = analytics.New(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
 	var rootResolver *resolver.Resolver
 	{
 		config := resolver.ResolverConfig{
 			Log:                    s.log,
+			Analytics:              analyticsReporter,
 			InstallationProvider:   s.installationProvider,
 			InstallationCodename:   s.installationCodename,
 			InstallationK8sApiUrl:  s.installationK8sApiUrl,


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/18033
Needs https://github.com/giantswarm/config/pull/479

This PR adds support for submitting RUM events to our Google Firestore record. Submitting an event is done via a GraphQL mutation.

The event submitting logic is copied and refactored from `api`.