### PR TITLE
Update Ingress resources to be compatible with k8s 1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated Ingress resources in helm chart. This drops support for Kubernetes < 1.19.
+- Updated Ingress resources in helm chart.
 
 ## [1.4.0] - 2021-09-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated Ingress resources in helm chart.
+- Updated Ingress resources in helm chart. This drops support for Kubernetes < 1.19.
 
 ## [1.4.0] - 2021-09-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated Ingress resources in helm chart.
+
 ## [1.4.0] - 2021-09-29
 
 ### Added

--- a/helm/athena/Chart.yaml
+++ b/helm/athena/Chart.yaml
@@ -6,4 +6,3 @@ version: [[ .Version ]]
 appVersion: [[ .AppVersion ]]
 annotations:
   config.giantswarm.io/version: 1.x.x
-kubeVersion: ">=1.19.0-0"

--- a/helm/athena/Chart.yaml
+++ b/helm/athena/Chart.yaml
@@ -6,3 +6,4 @@ version: [[ .Version ]]
 appVersion: [[ .AppVersion ]]
 annotations:
   config.giantswarm.io/version: 1.x.x
+kubeVersion: ">=1.19.0-0"

--- a/helm/athena/templates/certs-secret.yaml
+++ b/helm/athena/templates/certs-secret.yaml
@@ -1,7 +1,7 @@
 {{- if not .Values.services.athena.letsencrypt }}
 apiVersion: v1
 kind: Secret
-type: Opaque
+type: kubernetes.io/tls
 metadata:
   name: "{{ .Values.name }}-certs-secret"
   namespace: {{ .Release.Namespace }}

--- a/helm/athena/templates/ingress.yaml
+++ b/helm/athena/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.name }}
@@ -20,9 +20,12 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: {{ .Values.name }}
-          servicePort: 8000
+          service:
+            name: {{ .Values.name }}
+            port:
+              number: 8000
   tls:
   - hosts:
     - {{ .Values.services.athena.host }}

--- a/helm/athena/templates/ingress.yaml
+++ b/helm/athena/templates/ingress.yaml
@@ -1,4 +1,8 @@
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
 apiVersion: networking.k8s.io/v1
+{{- else }}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ .Values.name }}
@@ -23,10 +27,15 @@ spec:
       - path: /
         pathType: ImplementationSpecific
         backend:
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
           service:
             name: {{ .Values.name }}
             port:
               number: 8000
+{{- else }}
+          serviceName: {{ .Values.name }}
+          servicePort: 8000
+{{- end }}
   tls:
   - hosts:
     - {{ .Values.services.athena.host }}

--- a/helm/athena/templates/ingress.yaml
+++ b/helm/athena/templates/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     {{- if .Values.services.athena.letsencrypt}}
     kubernetes.io/tls-acme: "true"
+    cert-manager.io/cluster-issuer: "letsencrypt-giantswarm"
     {{- end }}
 
     {{- if .Values.security.subnet.restrictAccess.gsAPI }}

--- a/helm/athena/values.yaml
+++ b/helm/athena/values.yaml
@@ -9,7 +9,6 @@ image:
 
 ingress:
   tls:
-    caPemB64: ""
     crtPemB64: ""
     keyPemB64: ""
 


### PR DESCRIPTION
This PR

- Adds Ingress compatibility for clusters above Kubernetes < 1.22
- Change the type of the certificate secrets to kubernetes/tls. This enables monitoring of said certificate using cert-exporter

## Checklist

- [x] Update changelog in CHANGELOG.md.
