### PR TITLE
add job to fix upgrade issue recreating secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated Ingress resources in helm chart.
+- Add workaround for Chart upgrade not working when not using lets encrypt due to changed secret type.
 
 ## [1.4.0] - 2021-09-29
 

--- a/helm/athena/templates/_helpers.tpl
+++ b/helm/athena/templates/_helpers.tpl
@@ -13,3 +13,22 @@
 {{- join "," $CIDRs.whitelist -}}
 
 {{- end -}}
+
+{{- define "athena.fixJob" -}}
+{{- printf "%s-%s" .Chart.Name "fix-job" -}}
+{{- end -}}
+
+{{- define "athena.fixJobSelectorLabels" -}}
+app.kubernetes.io/name: "{{ template "athena.fixJob" . }}"
+app.kubernetes.io/instance: "{{ template "athena.fixJob" . }}"
+{{- end -}}
+
+{{- define "athena.fixJobAnnotations" -}}
+"helm.sh/hook": "pre-upgrade"
+"helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+{{- end -}}
+
+{{/* Create a label which can be used to select any orphaned fix-job hook resources */}}
+{{- define "athena.fixJobSelector" -}}
+{{- printf "%s" "fix-job-hook" -}}
+{{- end -}}

--- a/helm/athena/templates/fixjob/fixjob-job.yaml
+++ b/helm/athena/templates/fixjob/fixjob-job.yaml
@@ -1,0 +1,54 @@
+{{- if and (not .Values.services.athena.letsencrypt) .Release.IsUpgrade .Values.fixJob.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "athena.fixJob" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-1"
+    {{- include "athena.fixJobAnnotations" . | nindent 4 }}
+    ignore-check.kube-linter.io/no-read-only-root-fs: "kubectl"
+  labels:
+    app.kubernetes.io/component: {{ include "athena.fixJob" . | quote }}
+    {{- include "athena.fixJobSelectorLabels" . | nindent 4 }}
+    role: {{ include "athena.fixJobSelector" . | quote }}
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: {{ include "athena.fixJob" . | quote }}
+        {{- include "athena.fixJobSelectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "athena.fixJob" . }}
+      securityContext:
+        runAsUser: 65534
+        runAsGroup: 65534
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: kubectl
+        image: "{{ .Values.registry.domain }}/giantswarm/docker-kubectl:latest"
+        command:
+        - sh
+        - -c
+        - |
+          set -o errexit ; set -o xtrace ; set -o nounset
+
+          # piping stderr to stdout means kubectl's errors are surfaced
+          # in the pod's logs.
+
+          # Temporary fix to work around secret type change
+          kubectl -n {{ .Release.Namespace }} delete secret {{ .Values.name }}-certs-secret 2>&1
+
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+      restartPolicy: Never
+  backoffLimit: 4
+{{- end }}

--- a/helm/athena/templates/fixjob/fixjob-np.yaml
+++ b/helm/athena/templates/fixjob/fixjob-np.yaml
@@ -1,0 +1,38 @@
+{{- if and (not .Values.services.athena.letsencrypt) .Release.IsUpgrade .Values.fixJob.enabled }}
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: {{ include "athena.fixJob" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-7"
+    {{- include "athena.fixJobAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "athena.fixJob" . | quote }}
+    {{- include "athena.fixJobSelectorLabels" . | nindent 4 }}
+    role: {{ include "athena.fixJobSelector" . | quote }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: {{ include "athena.fixJob" . | quote }}
+      {{- include "athena.fixJobSelectorLabels" . | nindent 6 }}
+  # allow egress traffic to the Kubernetes API
+  egress:
+  - ports:
+    - port: 443
+      protocol: TCP
+    # legacy port kept for compatibility
+    - port: 6443
+      protocol: TCP
+    to:
+    {{- range tuple "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16" "100.64.0.0/10" }}
+    - ipBlock:
+        cidr: {{ . }}
+    {{- end }}
+  # deny ingress traffic
+  ingress: []
+  policyTypes:
+  - Egress
+  - Ingress
+{{- end }}

--- a/helm/athena/templates/fixjob/fixjob-psp.yaml
+++ b/helm/athena/templates/fixjob/fixjob-psp.yaml
@@ -1,0 +1,36 @@
+{{- if and (not .Values.services.athena.letsencrypt) .Release.IsUpgrade .Values.fixJob.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "athena.fixJob" . }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-6"
+    {{- include "athena.fixJobAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "athena.fixJob" . | quote }}
+    {{- include "athena.fixJobSelectorLabels" . | nindent 4 }}
+    role: {{ include "athena.fixJobSelector" . | quote }}
+spec:
+  privileged: false
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  volumes:
+  - 'secret'
+  hostPID: false
+  hostIPC: false
+  hostNetwork: false
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/helm/athena/templates/fixjob/fixjob-rbac.yaml
+++ b/helm/athena/templates/fixjob/fixjob-rbac.yaml
@@ -1,0 +1,53 @@
+{{- if and (not .Values.services.athena.letsencrypt) .Release.IsUpgrade .Values.fixJob.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "athena.fixJob" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-3"
+    {{- include "athena.fixJobAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "athena.fixJob" . | quote }}
+    {{- include "athena.fixJobSelectorLabels" . | nindent 4 }}
+    role: {{ include "athena.fixJobSelector" . | quote }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secret
+  verbs:
+  - list
+  - delete
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - {{ include "athena.fixJob" . }}
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "athena.fixJob" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-2"
+    {{- include "athena.fixJobAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "athena.fixJob" . | quote }}
+    {{- include "athena.fixJobSelectorLabels" . | nindent 4 }}
+    role: {{ include "athena.fixJobSelector" . | quote }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "athena.fixJob" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "athena.fixJob" . }}
+    namespace: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/helm/athena/templates/fixjob/fixjob-serviceaccount.yaml
+++ b/helm/athena/templates/fixjob/fixjob-serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if and (not .Values.services.athena.letsencrypt) .Release.IsUpgrade .Values.fixJob.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "athena.fixJob" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-4"
+    {{- include "athena.fixJobAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "athena.fixJob" . | quote }}
+    {{- include "athena.fixJobSelectorLabels" . | nindent 4 }}
+    role: {{ include "athena.fixJobSelector" . | quote }}
+{{- end }}

--- a/helm/athena/values.yaml
+++ b/helm/athena/values.yaml
@@ -55,3 +55,12 @@ registry:
   domain: docker.io
   pullSecret:
     dockerConfigJSON: ""
+
+# Job installed by Helm hook to work
+# around type field being immutable
+# in Kubernetes secrets
+#
+# Has no effect for fresh installations
+# and services.athena.letsencrypt=true
+fixJob:
+  enabled: true


### PR DESCRIPTION
This PR is a follow up to #56 which introduces a breaking change which this PR will ease.

It adds a Job deleting existing Secrets but only on upgrades and for deployments with disabled lets encrypt.


## Checklist

-  [x] Update changelog in CHANGELOG.md.
