### PR TITLE
Fix setting the collection name based on the environment type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Firestore collection name used for writing RUM data.
+
 ## [1.5.2] - 2022-02-14
 
 ### Fixed

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -51,6 +51,7 @@ func New(config Config) (*Analytics, error) {
 	a := &Analytics{
 		log:             config.Log,
 		firestoreClient: firestoreClient,
+		environment:     config.Environment,
 	}
 
 	return a, nil

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -92,7 +92,7 @@ func (a *Analytics) validateEvent(e Event) error {
 }
 
 func (a *Analytics) applyDefaultsToEvent(e Event) Event {
-	if len(e.EnvironmentClass) < 1 {
+	if e.EnvironmentClass == "" {
 		e.EnvironmentClass = a.environment
 	}
 

--- a/pkg/analytics/spec.go
+++ b/pkg/analytics/spec.go
@@ -23,6 +23,8 @@ type Reporter interface {
 	Report(ctx context.Context, event Event) (Event, error)
 }
 
+// CollectionName creates a firestore collection name
+// based on the year, month, and environment type (stable, testing).
 func (e *Event) CollectionName() string {
 	envClass := strings.ToLower(e.EnvironmentClass)
 


### PR DESCRIPTION
Fixes the problem that all RUM data was written into collections named like `2022-03-` instead of `2022-03-testing` and `2022-03-stable`.

## Checklist

- [x] Update changelog in CHANGELOG.md.
