### PR TITLE
fix templating of provider value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix templating of `provider` value when app is installed from the `giantswarm` catalog.
+
 ## [1.6.0] - 2022-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,12 +14,9 @@ The app is installed in workload clusters, via our [app platform](https://docs.g
 
 Other than the app itself, you will need to provide a `values.yaml` configuration.
 
-The cluster CA and provider are needed as minimal configuration.
+The cluster CA is needed as minimal configuration.
 
 ```yaml
-provider:
-  kind: aws
-
 kubernetes:
   caPem: |
     -----BEGIN CERTIFICATE-----
@@ -30,7 +27,7 @@ kubernetes:
  `.kubernetes.caPem` is the CA certificate of your workload cluster in PEM format. At Giant Swarm, you can retrieve this certificate via the [kubectl gs login](https://docs.giantswarm.io/ui-api/kubectl-gs/login/) command, when creating a client certificate for the workload cluster. It ends up in Base46-encoded form in your kubectl config file. The CA certificate is required by Dex K8s Authenticator.
 
 
-It is also possible to override the api and issuer addresses as well as the cluster name in case it is needed:
+It is also possible to override the api and issuer addresses as well as the cluster name and provider in case it is needed:
 ```yaml
 provider:
   kind: aws

--- a/helm/athena/templates/configmap.yaml
+++ b/helm/athena/templates/configmap.yaml
@@ -12,7 +12,10 @@ data:
       - "{{ .Values.services.happa.address }}"
       listenAddress: "0.0.0.0:8000"
     identity:
+      {{- if .Values.provider.kind }}
       provider: "{{ .Values.provider.kind }}"
+      {{- else }}
+      provider: "{{ .Values.provider }}"
       {{- if .Values.managementCluster.name }}
       codename: "{{ .Values.managementCluster.name }}"
       {{- else }}

--- a/helm/athena/templates/configmap.yaml
+++ b/helm/athena/templates/configmap.yaml
@@ -16,6 +16,7 @@ data:
       provider: "{{ .Values.provider.kind }}"
       {{- else }}
       provider: "{{ .Values.provider }}"
+      {{- end }}
       {{- if .Values.managementCluster.name }}
       codename: "{{ .Values.managementCluster.name }}"
       {{- else }}

--- a/helm/athena/values.schema.json
+++ b/helm/athena/values.schema.json
@@ -99,7 +99,7 @@
             }
         },
         "provider": {
-            "type": "object",
+            "type": ["integer", "string"],
             "properties": {
                 "kind": {
                     "type": "string"

--- a/helm/athena/values.schema.json
+++ b/helm/athena/values.schema.json
@@ -99,7 +99,7 @@
             }
         },
         "provider": {
-            "type": ["integer", "string"],
+            "type": ["object", "string"],
             "properties": {
                 "kind": {
                     "type": "string"

--- a/helm/athena/values.yaml
+++ b/helm/athena/values.yaml
@@ -26,6 +26,7 @@ managementCluster:
 oidc:
   issuerAddress: ""
 
+# provider can be a string or an object
 provider:
   kind: ""
 


### PR DESCRIPTION
`provider` is set by default when installing an app from the giantswarm catalog. This caused a conflict and failed schema validation. This allows to set it both ways. :)

## Checklist

- [x] Update changelog in CHANGELOG.md.
