### PR TITLE
Fix URL in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix broken relative link in README
+
 ## [1.6.2] - 2022-06-09
 
 ## [1.6.1] - 2022-06-09

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ security:
 
 ## Examples
 
-You can find example queries in the [examples folder](./examples). You can execute these in the GraphQL playground app (at the `/` route).
+You can find example queries in the [examples folder](https://github.com/giantswarm/athena/blob/main/examples). You can execute these in the GraphQL playground app (at the `/` route).
 
 ## How to add a new property?
 


### PR DESCRIPTION
## Checklist

- [x] Update changelog in CHANGELOG.md.

I noticed while checking out the app in `happa` that the link to the `examples` folder in the README is relative and leads to a 404 page. I changed it to an absolute link instead.