### PR TITLE
Parse certificate sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Updated CA certificate parsing to sanitize leading nd trailing white spaces and newlines
+
 ## [1.7.4] - 2022-09-12
 
 ## [1.7.3] - 2022-09-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Updated CA certificate parsing to sanitize leading nd trailing white spaces and newlines
+- Updated CA certificate parsing to sanitize leading and trailing white spaces and newlines
 
 ## [1.7.4] - 2022-09-12
 

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -16,6 +16,7 @@ const (
 func Parse(cert string) string {
 	cert = strings.TrimPrefix(cert, yamlMultiLinePrefix)
 
+	cert = strings.TrimSpace(cert)
 	cert = strings.TrimPrefix(cert, certPrefix)
 	cert = strings.TrimSuffix(cert, certSuffix)
 	cert = strings.TrimSpace(cert)

--- a/pkg/certificate/certificate_test.go
+++ b/pkg/certificate/certificate_test.go
@@ -68,6 +68,30 @@ lastthing
 
 -----END CERTIFICATE-----`,
 		},
+		{
+			name: "case 6: parse a certificate with leading and trailing spaces",
+			cert: `  -----BEGIN CERTIFICATE----- something otherthing lastthing -----END CERTIFICATE-----  `,
+			expected: `-----BEGIN CERTIFICATE-----
+something
+otherthing
+lastthing
+-----END CERTIFICATE-----`,
+		},
+		{
+			name: "case 7: parse a certificate with leading and trailing newline",
+			cert: `
+-----BEGIN CERTIFICATE-----
+something
+otherthing
+lastthing
+-----END CERTIFICATE-----
+`,
+			expected: `-----BEGIN CERTIFICATE-----
+something
+otherthing
+lastthing
+-----END CERTIFICATE-----`,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Updated CA certificate parsing to sanitize leading and trailing white spaces and newlines

## Checklist

- [x] Update changelog in CHANGELOG.md.
