### PR TITLE
Added read header timeout to http server

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -1,3 +1,2 @@
 # Consul - no fix yet
 CVE-2022-29153 until=2022-12-01
-CVE-2022-24687 until=2022-12-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add CI job to push to `openstack-app-collection`.
 - Add CI job to push to `gcp-app-collection`.
+- Configured read header timeout in the http server
 
 ## [1.7.5] - 2022-09-15
 

--- a/go.mod
+++ b/go.mod
@@ -60,4 +60,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.0 // indirect
 )
 
-replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+replace (
+	github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+	github.com/hashicorp/consul/api => github.com/hashicorp/consul/api v1.15.2
+)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/99designs/gqlgen/graphql/handler"
 	"github.com/99designs/gqlgen/graphql/playground"
@@ -12,6 +13,10 @@ import (
 	"github.com/giantswarm/athena/pkg/graph/exec"
 	"github.com/giantswarm/athena/pkg/graph/resolver"
 	"github.com/giantswarm/athena/pkg/server/middleware"
+)
+
+const (
+	readHeaderTimeout = 60 * time.Second
 )
 
 type Config struct {
@@ -130,8 +135,9 @@ func (s *Server) Boot() error {
 	}
 
 	server := &http.Server{
-		Addr:    s.listenAddress,
-		Handler: mux,
+		Addr:              s.listenAddress,
+		Handler:           mux,
+		ReadHeaderTimeout: readHeaderTimeout,
 	}
 
 	s.log.Infof("server listening on address %s", s.listenAddress)


### PR DESCRIPTION
Fixed `gosec` error by adding 60s read header timeout to the http server