### PR TITLE
Add ciliumnetworkpoliccy for the fix helm job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-
 ## [Unreleased]
+
+### Added
+
+- Added `CiliumNetworkPolicy` for the CRD install job.
+
+### Changed
+
+- The helm job that installs CRDs is not removed if the job fails.
 
 ## [1.7.6] - 2022-10-25
 

--- a/helm/athena/templates/_helpers.tpl
+++ b/helm/athena/templates/_helpers.tpl
@@ -51,7 +51,7 @@ app.kubernetes.io/instance: "{{ template "athena.fixJob" . }}"
 
 {{- define "athena.fixJobAnnotations" -}}
 "helm.sh/hook": "pre-upgrade"
-"helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
+"helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
 {{- end -}}
 
 {{/* Create a label which can be used to select any orphaned fix-job hook resources */}}

--- a/helm/athena/templates/fixjob/fixjob-np.yaml
+++ b/helm/athena/templates/fixjob/fixjob-np.yaml
@@ -1,4 +1,33 @@
 {{- if and (not .Values.services.athena.letsencrypt) .Release.IsUpgrade .Values.fixJob.enabled }}
+  {{- if .Capabilities.APIVersions.Has "cilium.io/v2" }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "athena.fixJob" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    # create hook dependencies in the right order
+    "helm.sh/hook-weight": "-7"
+    {{- include "athena.fixJobAnnotations" . | nindent 4 }}
+  labels:
+    app.kubernetes.io/component: {{ include "athena.fixJob" . | quote }}
+    {{- include "athena.fixJobSelectorLabels" . | nindent 4 }}
+    role: {{ include "athena.fixJobSelector" . | quote }}
+spec:
+  endpointSelector:
+    matchLabels:
+      matchLabels:
+        app.kubernetes.io/component: {{ include "athena.fixJob" . | quote }}
+        {{- include "athena.fixJobSelectorLabels" . | nindent 6 }}
+  egress:
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "443"
+        - ports:
+            - port: "6443"
+  {{- else}}
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -35,4 +64,5 @@ spec:
   policyTypes:
   - Egress
   - Ingress
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
Now that we use cilium as our CNI, the network policies that rely on ipBlock won't work. We need to add a ciliumnetworkpolicy instead.

## Checklist

- [X] Update changelog in CHANGELOG.md.
