### PR TITLE
Polymorphic managementCluster value in Helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for polymorphic values of `managementCluster` - it can be defined either as `string` or as `object`.
+
 ## [1.8.1] - 2022-11-14
 
 ### Fixed

--- a/helm/athena/templates/configmap.yaml
+++ b/helm/athena/templates/configmap.yaml
@@ -17,7 +17,11 @@ data:
       {{- else }}
       provider: "{{ .Values.provider.kind }}"
       {{- end }}
-      {{- if .Values.clusterID }}
+      {{- if and (eq (kindOf .Values.managementCluster) "string") (.Values.clusterID) }}
+      codename: "{{ .Values.managementCluster }}-{{ .Values.clusterID }}"
+      {{- else if (eq (kindOf .Values.managementCluster) "string") }}
+      codename: "{{ .Values.managementCluster }}"
+      {{- else if .Values.clusterID }}
       codename: "{{ .Values.managementCluster.name }}-{{ .Values.clusterID }}"
       {{- else }}
       codename: "{{ .Values.managementCluster.name }}"

--- a/helm/athena/values.schema.json
+++ b/helm/athena/values.schema.json
@@ -77,7 +77,7 @@
             }
         },
         "managementCluster": {
-            "type": "object",
+            "type": ["object", "string"],
             "properties": {
                 "name": {
                     "type": "string"


### PR DESCRIPTION
Added a possibility to specify `managementCluster` value in the Helm chart as both `string` and `object`.

## Checklist

- [x] Update changelog in CHANGELOG.md.
