### PR TITLE
allow-configuration-of-cluster-issuer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add option to configure custom clusterIssuer for certificate generation.
+
 ## [1.8.2] - 2022-11-24
 
 ### Added

--- a/helm/athena/templates/ingress.yaml
+++ b/helm/athena/templates/ingress.yaml
@@ -10,11 +10,11 @@ metadata:
   labels:
     {{- include "athena.labels.common" . | nindent 4 }}
   annotations:
-    {{- if .Values.services.athena.letsencrypt}}
-    kubernetes.io/tls-acme: "true"
-    cert-manager.io/cluster-issuer: "letsencrypt-giantswarm"
+    {{- if .Values.ingress.tls.letsencrypt }}
+    cert-manager.io/cluster-issuer: letsencrypt-giantswarm
+    {{- else if ne .Values.ingress.tls.clusterIssuer "" }}
+    cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
     {{- end }}
-
     {{- if .Values.security.subnet.restrictAccess.gsAPI }}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ template "whitelistCIDR" . }}
     {{- end }}

--- a/helm/athena/values.schema.json
+++ b/helm/athena/values.schema.json
@@ -50,11 +50,17 @@
                 "tls": {
                     "type": "object",
                     "properties": {
+                        "clusterIssuer": {
+                            "type": "string"
+                        },
                         "crtPemB64": {
                             "type": "string"
                         },
                         "keyPemB64": {
                             "type": "string"
+                        },
+                        "letsencrypt": {
+                            "type": "boolean"
                         }
                     }
                 }
@@ -173,9 +179,6 @@
                         },
                         "host": {
                             "type": "string"
-                        },
-                        "letsencrypt": {
-                            "type": "boolean"
                         }
                     }
                 },

--- a/helm/athena/values.yaml
+++ b/helm/athena/values.yaml
@@ -12,6 +12,8 @@ baseDomain: ""
 
 ingress:
   tls:
+    letsencrypt: true
+    clusterIssuer: ""
     crtPemB64: ""
     keyPemB64: ""
 
@@ -45,7 +47,6 @@ services:
   athena:
     address: ""
     host: ""
-    letsencrypt: true
 
 analytics:
   environmentType: ""


### PR DESCRIPTION
necessary for private MCs where certs are issued by private CA but managed by cert-manager

test on fully private MC