### PR TITLE
Fixed definition of labels in certs-secret Helm template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed labels in certs-secret Helm template
+
 ### Removed
 
 - Remove CA pem example from readme as it is no longer required

--- a/helm/athena/templates/certs-secret.yaml
+++ b/helm/athena/templates/certs-secret.yaml
@@ -5,8 +5,8 @@ type: kubernetes.io/tls
 metadata:
   name: "{{ .Values.name }}-certs-secret"
   namespace: {{ .Release.Namespace }}
-labels:
-  {{- include "athena.labels.common" . | nindent 2 }}
+  labels:
+    {{- include "athena.labels.common" . | nindent 4 }}
 data:
   tls.crt: {{ .Values.ingress.tls.crtPemB64 | quote }}
   tls.key: {{ .Values.ingress.tls.keyPemB64 | quote }}


### PR DESCRIPTION
Labels in the certs-secret Helm template had an incorrect indentation. This PR fixes it.

It may also help fix https://github.com/giantswarm/roadmap/issues/1744

## Checklist

- [x] Update changelog in CHANGELOG.md.
