### PR TITLE
support for dns record creation via external-dns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add additional annotations on all `ingress` objects to support DNS record creation via `external-dns`
 - Added the Runtime Default seccompprofile
 
 ## [1.9.1] - 2022-12-21

--- a/helm/athena/templates/ingress.yaml
+++ b/helm/athena/templates/ingress.yaml
@@ -18,6 +18,14 @@ metadata:
     {{- if .Values.security.subnet.restrictAccess.gsAPI }}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ template "whitelistCIDR" . }}
     {{- end }}
+    {{- if .Values.ingress.externalDNS }}
+    {{- if .Values.services.athena.host }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.services.athena.host }}
+    {{- else }}
+    external-dns.alpha.kubernetes.io/hostname: athena.{{ .Values.baseDomain }}
+    {{- end }}
+    giantswarm.io/external-dns: managed
+    {{- end }}
 spec:
   ingressClassName: nginx
   rules:

--- a/helm/athena/values.schema.json
+++ b/helm/athena/values.schema.json
@@ -47,6 +47,9 @@
         "ingress": {
             "type": "object",
             "properties": {
+                "externalDNS": {
+                    "type": "boolean"
+                },
                 "tls": {
                     "type": "object",
                     "properties": {
@@ -84,7 +87,10 @@
             }
         },
         "managementCluster": {
-            "type": ["object", "string"],
+            "type": [
+                "object",
+                "string"
+            ],
             "properties": {
                 "name": {
                     "type": "string"
@@ -106,7 +112,10 @@
             }
         },
         "provider": {
-            "type": ["object", "string"],
+            "type": [
+                "object",
+                "string"
+            ],
             "properties": {
                 "kind": {
                     "type": "string"

--- a/helm/athena/values.yaml
+++ b/helm/athena/values.yaml
@@ -11,6 +11,7 @@ clusterID: ""
 baseDomain: ""
 
 ingress:
+  externalDNS: false
   tls:
     letsencrypt: true
     clusterIssuer: ""


### PR DESCRIPTION
to support dns-record creation via external-dns, two additional annotations are needed to make external-dns work on athena created ingress objects.

towards: https://github.com/giantswarm/roadmap/issues/1037
related config repo change: https://github.com/giantswarm/config/pull/1608

## Checklist

- [x] Update changelog in CHANGELOG.md.
