### PR TITLE
Default clusterIssuer to letsencrypt-giantswarm and update ingress annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Default clusterIssuer to letsencrypt-giantswarm and update ingress annotation
+
 ## [1.12.1] - 2023-12-11
 
 ### Changed

--- a/helm/athena/templates/ingress.yaml
+++ b/helm/athena/templates/ingress.yaml
@@ -10,11 +10,7 @@ metadata:
   labels:
     {{- include "athena.labels.common" . | nindent 4 }}
   annotations:
-    {{- if .Values.ingress.tls.letsencrypt }}
-    cert-manager.io/cluster-issuer: letsencrypt-giantswarm
-    {{- else if ne .Values.ingress.tls.clusterIssuer "" }}
     cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
-    {{- end }}
     {{- if .Values.security.subnet.restrictAccess.gsAPI }}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ template "whitelistCIDR" . }}
     {{- end }}

--- a/helm/athena/values.yaml
+++ b/helm/athena/values.yaml
@@ -15,7 +15,7 @@ ingress:
   externalDNS: false
   tls:
     letsencrypt: true
-    clusterIssuer: ""
+    clusterIssuer: "letsencrypt-giantswarm"
     crtPemB64: ""
     keyPemB64: ""
 


### PR DESCRIPTION
Towards https://gigantic.slack.com/archives/C02EVLE9W/p1718114991393929

- Default clusterIssuer to letsencrypt-giantswarm and update ingress annotation

Related:
- https://github.com/giantswarm/dex-app/pull/352

## Checklist

- [x] Update changelog in CHANGELOG.md.
