### PR TITLE
Made GraphQL introspection configurable and disabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Made GraphQL introspection configurable and disabled by default
+
 ### Changed
 
 - Change ImagePullPolicy from Always to IfNotPresent to reduce image network traffic.

--- a/cmd/daemon/runner.go
+++ b/cmd/daemon/runner.go
@@ -72,6 +72,7 @@ func (r *runner) run(ctx context.Context, cmd *cobra.Command, args []string) err
 			Log:                      r.log,
 			AllowedOrigins:           r.viper.GetStringSlice("server.allowedOrigins"),
 			ListenAddress:            r.viper.GetString("server.listenAddress"),
+			EnableIntrospection:      r.viper.GetBool("server.enableIntrospection"),
 			InstallationProvider:     r.viper.GetString("identity.provider"),
 			InstallationCodename:     r.viper.GetString("identity.codename"),
 			InstallationK8sApiUrl:    r.viper.GetString("kubernetes.apiUrl"),

--- a/helm/athena/templates/configmap.yaml
+++ b/helm/athena/templates/configmap.yaml
@@ -11,6 +11,9 @@ data:
       allowedOrigins:
       - "{{ .Values.services.happa.address }}"
       listenAddress: "0.0.0.0:8000"
+      {{- if .Values.graphql }}
+      enableIntrospection: {{ .Values.graphql.enableIntrospection }}
+      {{- end }}
     identity:
       {{- if (eq (kindOf .Values.provider) "string") }}
       provider: "{{ .Values.provider }}"

--- a/helm/athena/values.schema.json
+++ b/helm/athena/values.schema.json
@@ -31,7 +31,18 @@
                     }
                 }
             }
-        },        
+        },
+        "graphql": {
+            "type": "object",
+            "properties": {
+                "enableIntrospection": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "enableIntrospection"
+            ]
+        },
         "groupID": {
             "type": "integer"
         },

--- a/helm/athena/values.yaml
+++ b/helm/athena/values.yaml
@@ -70,6 +70,9 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 
+graphql:
+  enableIntrospection: false
+
 global:
   podSecurityStandards:
-    enforced: false
+    enforced: true

--- a/pkg/graph/server/server.go
+++ b/pkg/graph/server/server.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"time"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/extension"
+	"github.com/99designs/gqlgen/graphql/handler/lru"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
+)
+
+func New(es graphql.ExecutableSchema, enableIntrospection bool) *handler.Server {
+	srv := handler.New(es)
+	srv.AddTransport(transport.Websocket{
+		KeepAlivePingInterval: 10 * time.Second,
+	})
+	srv.AddTransport(transport.Options{})
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
+	srv.AddTransport(transport.MultipartForm{})
+
+	srv.SetQueryCache(lru.New(1000))
+
+	if enableIntrospection {
+		srv.Use(extension.Introspection{})
+	}
+	srv.Use(extension.AutomaticPersistedQuery{
+		Cache: lru.New(100),
+	})
+
+	return srv
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/giantswarm/athena/pkg/analytics"
 	"github.com/giantswarm/athena/pkg/graph/exec"
 	"github.com/giantswarm/athena/pkg/graph/resolver"
+	graphqlserver "github.com/giantswarm/athena/pkg/graph/server"
 	"github.com/giantswarm/athena/pkg/server/middleware"
 )
 
@@ -31,6 +32,8 @@ type Config struct {
 	InstallationK8sCaCert    string
 	AnalyticsEnv             string
 	AnalyticsCredentialsJSON string
+
+	EnableIntrospection bool
 }
 
 type Server struct {
@@ -45,6 +48,7 @@ type Server struct {
 	installationK8sCaCert    string
 	analyticsEnv             string
 	analyticsCredentialsJSON string
+	enableIntrospection      bool
 }
 
 func New(config Config) (*Server, error) {
@@ -69,6 +73,7 @@ func New(config Config) (*Server, error) {
 		installationK8sCaCert:    config.InstallationK8sCaCert,
 		analyticsEnv:             config.AnalyticsEnv,
 		analyticsCredentialsJSON: config.AnalyticsCredentialsJSON,
+		enableIntrospection:      config.EnableIntrospection,
 	}
 
 	return s, nil
@@ -125,7 +130,7 @@ func (s *Server) Boot() error {
 		schema := exec.NewExecutableSchema(exec.Config{
 			Resolvers: rootResolver,
 		})
-		graphQLServer = handler.NewDefaultServer(schema)
+		graphQLServer = graphqlserver.New(schema, s.enableIntrospection)
 	}
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
## Checklist

Made it possible to configure whether GraphQL introspection should be enabled or not.

It is disabled by default, and it can be enabled by setting the `graphql.enableIntrospection` property in Helm values to `true`.

- [x] Update changelog in CHANGELOG.md.
