### PR TITLE
Remove unused firestoreServiceAccountKey value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed unused chart value `.secret.firestoreServiceAccountKey` and `.secret`.
+
 ## [1.13.0] - 2025-01-16
 
 ### Removed

--- a/helm/athena/values.schema.json
+++ b/helm/athena/values.schema.json
@@ -152,14 +152,6 @@
                 }
             }
         },
-        "secret": {
-            "type": "object",
-            "properties": {
-                "firestoreServiceAccountKey": {
-                    "type": "string"
-                }
-            }
-        },
         "security": {
             "type": "object",
             "properties": {

--- a/helm/athena/values.yaml
+++ b/helm/athena/values.yaml
@@ -55,9 +55,6 @@ analytics:
   environmentType: ""
   credentialsJSON: ""
 
-secret:
-  firestoreServiceAccountKey: ""
-
 # generic configuration
 registry:
   domain: gsoci.azurecr.io


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/31025

The value is no longer used by athena itself and has been removed from configs, too.

## Checklist

- [x] Update changelog in CHANGELOG.md.
