### PR TITLE
chart: make ingress annotations configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Make Ingress annotations configurable via values (`.Values.ingress.annotations`)
+
 ### Changed
 
 - Resolve golangci-lint v2 problems in athena by removing redundant explicit references to embedded Resolver struct fields to resolve staticcheck linter warning.

--- a/helm/athena/templates/ingress.yaml
+++ b/helm/athena/templates/ingress.yaml
@@ -13,6 +13,10 @@ metadata:
     cert-manager.io/cluster-issuer: {{ .Values.ingress.tls.clusterIssuer }}
     {{- if .Values.security.subnet.restrictAccess.gsAPI }}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ template "whitelistCIDR" . }}
+    {{- else }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- end }}
     {{- if .Values.ingress.externalDNS }}
     {{- if .Values.services.athena.host }}

--- a/helm/athena/values.schema.json
+++ b/helm/athena/values.schema.json
@@ -85,6 +85,9 @@
                             "type": "boolean"
                         }
                     }
+                },
+                "annotations": {
+                    "type": "object"
                 }
             }
         },

--- a/helm/athena/values.yaml
+++ b/helm/athena/values.yaml
@@ -18,6 +18,7 @@ ingress:
     clusterIssuer: "letsencrypt-giantswarm"
     crtPemB64: ""
     keyPemB64: ""
+  annotations: {}
 
 kubernetes:
   caPem: ""


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/33146

### Summary

Make the Ingress resource's annotations configurable, to allow for more flexible configuration of this app.

## Checklist

- [x] Update changelog in CHANGELOG.md.
